### PR TITLE
Include 0 so first block isn't skipped

### DIFF
--- a/lib/docBlockParser.js
+++ b/lib/docBlockParser.js
@@ -74,7 +74,7 @@ DocBlockParser.prototype.parse = function(source, type) {
     }
 
     var prevPos = this.source.length;
-    for (var i = docBlocks.length - 1; i > 0; i--) {
+    for (var i = docBlocks.length - 1; i >= 0; i--) {
         var block = docBlocks[i];
         var code = this.source.slice(block.pos, prevPos);
         prevPos = block.pos - block.raw.length;


### PR DESCRIPTION
Right now the first doc block will not include the method's code, because the loop terminates early at `i > 0`, so at `1`, instead of at `0`.